### PR TITLE
Modificación en el ejemplo 2 del módulo 5

### DIFF
--- a/modulo5/ejemplo2.md
+++ b/modulo5/ejemplo2.md
@@ -11,9 +11,8 @@ En este caso vamos a usar una imagen base de un sistema operativo sin ningún se
 ```Dockerfile
 # syntax=docker/dockerfile:1
 FROM debian:stable-slim
-RUN apt-get update && apt-get install -y apache2 libapache2-mod-php7.4 php7.4 && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apache2 libapache2-mod-php7.4 php7.4 && apt-get clean && rm -rf /var/lib/apt/lists/* && rm /var/www/html/index.html
 COPY app /var/www/html/
-RUN rm /var/www/html/index.html
 EXPOSE 80
 CMD apache2ctl -D FOREGROUND
 ```


### PR DESCRIPTION
La orden que elimina el index.html por defecto de Apache se puede ejecutar en el primer RUN, lo que evita crear una capa más en la imagen Docker.